### PR TITLE
Fix - Retain Post Attributes after calling any Post Endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.33)
+    lockstep_rails (0.3.34)
       rails
 
 GEM

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -685,7 +685,7 @@ module Lockstep
       if has_many_relations.keys.map { |relation| relation.to_s.to_sym }
         # TODO: make this a little smarter by checking if there are any Pointer objects in the objects attributes.
         # @attributes = self.class.to_s.constantize.where(:objectId => @attributes[self.id_ref]).first.attributes
-        @attributes = self.class.to_s.constantize.where(id_ref => @attributes[id_ref]).first.attributes.merge(@attributes)
+        @attributes = self.class.to_s.constantize.where(id_ref => @attributes[id_ref]).first.attributes
       end
     end
 

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -685,7 +685,7 @@ module Lockstep
       if has_many_relations.keys.map { |relation| relation.to_s.to_sym }
         # TODO: make this a little smarter by checking if there are any Pointer objects in the objects attributes.
         # @attributes = self.class.to_s.constantize.where(:objectId => @attributes[self.id_ref]).first.attributes
-        @attributes = self.class.to_s.constantize.where(id_ref => @attributes[id_ref]).first.attributes
+        @attributes = self.class.to_s.constantize.where(id_ref => @attributes[id_ref]).first.attributes.merge(@attributes)
       end
     end
 

--- a/app/models/lockstep/api_key.rb
+++ b/app/models/lockstep/api_key.rb
@@ -11,4 +11,6 @@ class Lockstep::ApiKey < Lockstep::ApiRecord
     resp = resource.post('', body: attrs, params: nil)
     result = post_result(resp)
   end
+
+  def merge_relations; end
 end

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = "0.3.33"
+  VERSION = "0.3.34"
 end


### PR DESCRIPTION
What is Changed?

- Changed Implementation to retain the attributes coming from Platform API and merge the post attributes after doing a get call again before returning the object.
