### PR TITLE
Fixed 401 error for create call in Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.40)
+    lockstep_rails (0.3.42)
       rails
 
 GEM
@@ -109,8 +109,11 @@ GEM
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -120,7 +123,7 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -202,7 +205,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     thor (1.2.1)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     vcr (6.1.0)

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -714,9 +714,9 @@ module Lockstep
       else
         error_response = JSON.parse(resp.body)
         pe = if error_response['error']
-               LockstepError.new(error_response['code'], error_response['error'])
+               Lockstep::Error.new(error_response['code'], error_response['error'])
              else
-               LockstepError.new(resp.code.to_s)
+               Lockstep::Error.new(resp.code.to_s)
              end
         self.errors.add(pe.code.to_s.to_sym, pe.msg)
         error_instances << pe

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = "0.3.41"
+  VERSION = "0.3.42"
 end


### PR DESCRIPTION
Screenshot of the 401 error not coming in the errors before the change:-
<img width="1440" alt="Screenshot 2022-12-08 at 5 33 10 PM" src="https://user-images.githubusercontent.com/18072571/206441995-d9e3ce03-66c5-45ff-9167-fbe2a8dfdf5e.png">


Screenshot of the 401 error coming in the errors attribute after the change:-
<img width="1440" alt="Screenshot 2022-12-08 at 5 30 04 PM" src="https://user-images.githubusercontent.com/18072571/206441473-54f59c02-36fa-44a9-a8a4-7199b78b70a4.png">

Screenshot for the successful Webhook create call:-
<img width="1440" alt="Screenshot 2022-12-08 at 6 50 15 PM" src="https://user-images.githubusercontent.com/18072571/206457630-a6c2c561-13b7-460b-9748-ed58b350647e.png">

Screenshot for 400 error when creating a Webhook:-
<img width="1440" alt="Screenshot 2022-12-08 at 6 55 54 PM" src="https://user-images.githubusercontent.com/18072571/206458055-f4c25f3a-cefb-4922-bb29-96b6dcf75b1b.png">

Screenshot of 401 error for the feature flag post call:-
<img width="1440" alt="Screenshot 2022-12-08 at 7 00 53 PM" src="https://user-images.githubusercontent.com/18072571/206459093-b89d0510-c1eb-4ba6-a07f-4b298b28e97b.png">