### PR TITLE
fix: handle_empty_hash_response_from_platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.51)
+    lockstep_rails (0.3.52)
       rails
 
 GEM

--- a/app/concepts/lockstep/query.rb
+++ b/app/concepts/lockstep/query.rb
@@ -241,6 +241,8 @@ class Lockstep::Query
       return results.to_i
     else
       results = parsed_response.is_a?(Array) ? parsed_response : parsed_response["records"]
+      return [] if results.blank?
+
       results = results[0..(criteria[:limit] - 1)] if criteria[:limit]
       get_relation_objects results.map { |r|
         # Convert camelcase to snake-case

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = '0.3.51'
+  VERSION = '0.3.52'
 end


### PR DESCRIPTION
In one of the new APIs I observed that Platform responds with just an empty hash. This is causing the gem to break. Hence handing if result is nil