### PR TITLE
Feature : Add Counts in All Get Calls based on Parameters passed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.55)
+    lockstep_rails (0.3.56)
       rails
 
 GEM

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = '0.3.55'
+  VERSION = '0.3.56'
 end

--- a/spec/models/lockstep/query_spec.rb
+++ b/spec/models/lockstep/query_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe 'Lockstep::Query' do
 
   context 'when generating' do
     it 'should build with the correct params' do
-      params =  Lockstep::Query.new(Lockstep::ApiRecord)
+      query =  Lockstep::Query.new(Lockstep::ApiRecord)
                                         .additional_query_params({'reportDate': Time.zone.today.strftime('%m/%d/%Y')})
                                         .where(domain_not_eq: 'lockstep.io', name: "test")
                                         .where(count_gteq: 20).where("email not_eq 'a@b.com'")
                                         .include_object(:contacts).limit(10)
-                                        .page(2).order(name: :asc).build_params
+                                        .page(2).order(name: :asc).with_count(true)
+      params = query.build_params
       expect(params[:filter]).to eq("(((domain NE 'lockstep.io') AND (name eq 'test')) AND (count GE 20)) AND (email not_eq 'a@b.com')")
       expect(params[:pageSize]).to eq(10)
       expect(params[:pageNumber]).to eq(2)
       expect(params[:include]).to eq("contacts")
       expect(params[:order]).to eq("NAME asc")
       expect(params.key?(:reportDate)).to eq true
+      expect(query.criteria[:with_count]).to eq true
     end
   end
 


### PR DESCRIPTION
What is changed?

- Ability to pass with_count as an configurable query to return the records and the total records which are present as per the query
- Generic way of handling so that the pre-existing support for all get calls is functioning as before (Passive Change)