### PR TITLE
Fix: Change return type to array over hash for with_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ Lockstep::Connection.count
 Lockstep::Connection.where(status: "Active").count
 # 100
 ```
-
+### With Count
+```ruby
+records , count = Lockstep::Connection.where(status: "active").with_count(true).execute
+# records get the records for the query and the with count if used will return the total nunber of records present for that query.
+```
 ### Limit
 You can limit the number of records being fetched by passing `limit`
 

--- a/app/concepts/lockstep/query.rb
+++ b/app/concepts/lockstep/query.rb
@@ -256,10 +256,7 @@ class Lockstep::Query
       }
 
       if criteria[:with_count]
-        {
-        records: records,
-        total_count: parsed_response["totalCount"]
-        }
+        [records, parsed_response["totalCount"]]
       else
         records
       end


### PR DESCRIPTION
What is Changed?

- Changed the return type from hash to array when using with_count in the query.