### PR TITLE
Fix: Change Bulk Import slice size to greater number on default if undefined.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.61)
+    lockstep_rails (0.3.62)
       rails
 
 GEM

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -423,8 +423,11 @@ module Lockstep
     #   raise StandardError.new("delete_all doesn't exist. Did you mean destroy_all?")
     # end
 
-    def self.bulk_import(new_objects, slice_size = 20)
+    def self.bulk_import(new_objects, slice_size = nil)
       return [] if new_objects.blank?
+
+      # default slice size to 1000, if its blank or if its 0
+      slice_size = 1000 if slice_size.blank? || slice_size.to_i == 0
 
       # Batch saves seem to fail if they're too big. We'll slice it up into multiple posts if they are.
       new_objects.each_slice(slice_size) do |objects|

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = '0.3.61'
+  VERSION = '0.3.62'
 end


### PR DESCRIPTION
# What Is Changed

Fixed Issue related to bulk_import using 20 as default.
Changed behaviour for the bulk_import to use 1000, if undefined by the end user. 