### PR TITLE
Adding #in_batches method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.63)
+    lockstep_rails (0.3.64)
       rails
 
 GEM

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -96,13 +96,13 @@ module Lockstep
           val
         end
       end
-      unless respond_to? "#{fname}="
-        class_eval do
-          define_method("#{fname}=") do |val|
-            set_attribute(fname.to_s, val)
+      return if respond_to? "#{fname}="
 
-            val
-          end
+      class_eval do
+        define_method("#{fname}=") do |val|
+          set_attribute(fname.to_s, val)
+
+          val
         end
       end
     end
@@ -200,19 +200,19 @@ module Lockstep
 
     def self.to_date_object(date)
       date = date.to_time if date.respond_to?(:to_time)
-      if date && (date.is_a?(Date) || date.is_a?(DateTime) || date.is_a?(Time))
-       date.getutc.iso8601(fraction_digits = 3)
-      end
+      return unless date && (date.is_a?(Date) || date.is_a?(DateTime) || date.is_a?(Time))
+
+      date.getutc.iso8601(fraction_digits = 3)
     end
 
     # Creates setter methods for model fields
     def create_setters!(k, _v)
-      unless respond_to? "#{k}="
-        self.class.send(:define_method, "#{k}=") do |val|
-          set_attribute(k.to_s, val)
+      return if respond_to? "#{k}="
 
-          val
-        end
+      self.class.send(:define_method, "#{k}=") do |val|
+        set_attribute(k.to_s, val)
+
+        val
       end
     end
 
@@ -248,10 +248,10 @@ module Lockstep
 
     # Creates getter methods for model fields
     def create_getters!(k, _v)
-      unless respond_to? k.to_s
-        self.class.send(:define_method, k.to_s) do
-          get_attribute(k.to_s)
-        end
+      return if respond_to? k.to_s
+
+      self.class.send(:define_method, k.to_s) do
+        get_attribute(k.to_s)
       end
     end
 
@@ -547,6 +547,11 @@ module Lockstep
       query_builder.where(*args)
     end
 
+    # Find a Lockstep::ApiRecord object by chaining #in_batches method calls.
+    def self.in_batches(batch_size: 100, &block)
+      query_builder.in_batches(batch_size: batch_size, &block)
+    end
+
     def self.additional_query_params(args)
       query_builder.additional_query_params(args)
     end
@@ -690,11 +695,11 @@ module Lockstep
       # KK 11-17-2012 The response after creation does not return full description of
       # the object nor the relations it contains. Make another request here.
       # TODO: @@has_many_relations structure has been changed from array to hash, need to evaluate the impact here
-      if has_many_relations.keys.map { |relation| relation.to_s.to_sym }
-        # TODO: make this a little smarter by checking if there are any Pointer objects in the objects attributes.
-        # @attributes = self.class.to_s.constantize.where(:objectId => @attributes[self.id_ref]).first.attributes
-        @attributes = self.class.to_s.constantize.where(id_ref => @attributes[id_ref]).first.attributes
-      end
+      return unless has_many_relations.keys.map { |relation| relation.to_s.to_sym }
+
+      # TODO: make this a little smarter by checking if there are any Pointer objects in the objects attributes.
+      # @attributes = self.class.to_s.constantize.where(:objectId => @attributes[self.id_ref]).first.attributes
+      @attributes = self.class.to_s.constantize.where(id_ref => @attributes[id_ref]).first.attributes
     end
 
     def post_result(resp)
@@ -848,12 +853,11 @@ module Lockstep
     end
 
     def attributes=(value)
-      if value.is_a?(Hash) && value.present?
-        value.each do |k, v|
-          send "#{k}=", v
-        end
+      return unless value.is_a?(Hash) && value.present?
+
+      value.each do |k, v|
+        send "#{k}=", v
       end
-      @attributes
     end
 
     def get_attribute(k)
@@ -873,9 +877,9 @@ module Lockstep
           result = attrs[k]['url']
         when 'Relation'
           objects_related_to_self = klass_name.constantize.where('$relatedTo' => {
-            'object' => { '__type' => 'Pointer',
-                          'className' => self.class.to_s, id_ref => id }, 'key' => k
-          }).all
+                                                                   'object' => { '__type' => 'Pointer',
+                                                                                 'className' => self.class.to_s, id_ref => id }, 'key' => k
+                                                                 }).all
           attrs[k] = Lockstep::RelationArray.new self, objects_related_to_self, k, klass_name
           @unsaved_attributes[k] = Lockstep::RelationArray.new self, objects_related_to_self, k, klass_name
           result = @unsaved_attributes[k]
@@ -1122,9 +1126,10 @@ module Lockstep
       define_singleton_method :record do
         resp = resource.get('')
 
-        return [] if %w(404).include?(resp.code.to_s)
-        # TODO handle non 200 response code. Throwing an exception for now
-        raise StandardError.new("#{resp.code} error while fetching: #{resp.body}") unless %w(201 200).include?(resp.code.to_s)
+        return [] if %w[404].include?(resp.code.to_s)
+        # TODO: handle non 200 response code. Throwing an exception for now
+        raise StandardError, "#{resp.code} error while fetching: #{resp.body}" unless %w[201
+                                                                                         200].include?(resp.code.to_s)
 
         result = JSON.parse(resp.body)
         r = result.transform_keys { |key| key.underscore }

--- a/app/concepts/lockstep/query.rb
+++ b/app/concepts/lockstep/query.rb
@@ -13,7 +13,7 @@ class Lockstep::Query
   #   both the where conditions in the above scenario is modifying the same object causing stack-overflow
   def clone
     c = Lockstep::Query.new(@klass)
-    c.criteria.deep_merge!(self.criteria.deep_dup)
+    c.criteria.deep_merge!(criteria.deep_dup)
     c
   end
 
@@ -24,12 +24,12 @@ class Lockstep::Query
   end
 
   def criteria
-    @criteria ||= { :conditions => [] }
+    @criteria ||= { conditions: [] }
   end
 
   def or(query)
     with_clone do
-      criteria[:conditions] << { type: "or", query: query }
+      criteria[:conditions] << { type: 'or', query: query }
     end
   end
 
@@ -41,7 +41,7 @@ class Lockstep::Query
 
   def where(args)
     if args.is_a?(Hash)
-      args.each do |k, v|
+      args.each do |_k, v|
         return none if v.is_a?(Array) and v.blank?
       end
     end
@@ -60,11 +60,12 @@ class Lockstep::Query
   def convert_arg(arg)
     return arg.to_pointer if arg.is_a?(Lockstep::ApiRecord)
     return Lockstep::ApiRecord.to_date_object(arg) if arg.is_a?(Time) || arg.is_a?(Date)
+
     if arg.is_a?(Hash)
       arg.keys.each do |key|
         @klass.valid_attribute?(key, raise_exception: true)
       end
-      return arg.update(arg) { |key, inner_arg| convert_arg(inner_arg) }
+      return arg.update(arg) { |_key, inner_arg| convert_arg(inner_arg) }
     end
 
     arg
@@ -90,6 +91,35 @@ class Lockstep::Query
       criteria[:include] += objects
       criteria[:include].uniq!
     end
+  end
+
+  def in_batches(batch_size: 100)
+    return if criteria[:none] || batch_size.zero?
+    return unless block_given?
+
+    params = build_params
+
+    page = criteria[:page] || 0
+    limit = criteria[:limit] || 0
+    fetched_records_count = 0
+
+    loop do
+      params[:pageNumber] = page
+      params[:pageSize] = limit.positive? ? [limit - fetched_records_count, batch_size].min : batch_size
+      break if params[:pageSize].zero?
+
+      results = get_results(params)
+      break unless results.present?
+
+      yield results
+
+      fetched_records_count += results.size
+      break if limit.positive? && fetched_records_count >= limit
+
+      page += 1
+    end
+
+    nil
   end
 
   def with_count(value)
@@ -136,18 +166,18 @@ class Lockstep::Query
   # end
 
   def build_filter
-    filter = ""
+    filter = ''
     criteria[:conditions].each do |condition|
       if condition.is_a?(Hash)
-        if condition[:type] == "or"
-          filter = build_filter_condition(filter, "OR", condition[:query].build_filter)
+        if condition[:type] == 'or'
+          filter = build_filter_condition(filter, 'OR', condition[:query].build_filter)
         else
           condition.each do |key, value|
-            filter = build_filter_condition(filter, "AND", build_filter_query(key, value))
+            filter = build_filter_condition(filter, 'AND', build_filter_query(key, value))
           end
         end
       elsif condition.is_a?(String)
-        filter = build_filter_condition(filter, "AND", condition)
+        filter = build_filter_condition(filter, 'AND', condition)
       end
     end
     filter
@@ -163,39 +193,39 @@ class Lockstep::Query
   end
 
   PREDICATES = {
-    _not_eq: "NE",
-    _eq: "EQ",
-    _gteq: "GE",
-    _gt: "GT",
-    _lteq: "LE",
-    _lt: "LT",
-    _in: "IN",
-    _contains: "CONTAINS",
-    _starts_with: "STARTSWITH",
-    _ends_with: "ENDSWITH",
-    _is: "IS",
+    _not_eq: 'NE',
+    _eq: 'EQ',
+    _gteq: 'GE',
+    _gt: 'GT',
+    _lteq: 'LE',
+    _lt: 'LT',
+    _in: 'IN',
+    _contains: 'CONTAINS',
+    _starts_with: 'STARTSWITH',
+    _ends_with: 'ENDSWITH',
+    _is: 'IS'
   }.with_indifferent_access
 
   def build_filter_query(key, value)
     key = key.to_s unless key.is_a?(String)
-    predicate = "eq" # default
+    predicate = 'eq' # default
     PREDICATES.each do |k, p|
-      if key.ends_with?(k)
-        key = key.gsub(k, "")
-        predicate = p
-        break
-      end
+      next unless key.ends_with?(k)
+
+      key = key.gsub(k, '')
+      predicate = p
+      break
     end
 
     # Build value
     if value.is_a?(Array)
-      value = "(#{value.map { |v| v.is_a?(String) ? "'#{v}'" : v }.join(",")})"
-      predicate = "in" if predicate == "eq"
-    elsif value.is_a?(String) and !["NULL", "NOT NULL"].include?(value)
+      value = "(#{value.map { |v| v.is_a?(String) ? "'#{v}'" : v }.join(',')})"
+      predicate = 'in' if predicate == 'eq'
+    elsif value.is_a?(String) and !['NULL', 'NOT NULL'].include?(value)
       value = "'#{value}'"
     elsif value.nil?
-      predicate = "IS" if predicate == "eq"
-      value = "NULL"
+      predicate = 'IS' if predicate == 'eq'
+      value = 'NULL'
     end
 
     "#{key.camelize(:lower)} #{predicate} #{value}"
@@ -203,20 +233,21 @@ class Lockstep::Query
 
   def build_params
     params = {}
-    params.merge!({ :filter => build_filter }) if criteria[:conditions]
+    params.merge!({ filter: build_filter }) if criteria[:conditions]
     # Lockstep Platform API does not support a page size of 1
-    params.merge!({ :pageSize => (criteria[:limit] == 1 ? 2 : criteria[:limit]) }) if criteria[:limit]
-    params.merge!({ :pageNumber => criteria[:page_number] }) if criteria[:page_number]
-    params.merge!({ :include => criteria[:include].join(",") }) if criteria[:include]
-    params.merge!({ :order => criteria[:order].join(",") }) if criteria[:order]
-    params.merge!({ :pageSize => 2 }) if criteria[:count]
+    params.merge!({ pageSize: (criteria[:limit] == 1 ? 2 : criteria[:limit]) }) if criteria[:limit]
+    params.merge!({ pageNumber: criteria[:page_number] }) if criteria[:page_number]
+    params.merge!({ include: criteria[:include].join(',') }) if criteria[:include]
+    params.merge!({ order: criteria[:order].join(',') }) if criteria[:order]
+    params.merge!({ pageSize: 2 }) if criteria[:count]
     params.merge!(criteria[:additional_query_params]) if criteria[:additional_query_params]
-    params.reject! { |k, v| v.blank? }
+    params.reject! { |_k, v| v.blank? }
     params
   end
 
   def execute
     return [] if criteria[:none]
+
     # This code automatically adds all related objects
     #
     # if @klass.has_many_relations
@@ -232,31 +263,33 @@ class Lockstep::Query
   end
 
   def get_results(params = {})
-    resp = @klass.resource.get(@klass.query_path, :params => params)
+    resp = @klass.resource.get(@klass.query_path, params: params)
 
-    return [] if %w(404).include?(resp.code.to_s)
-    # TODO handle non 200 response code. Throwing an exception for now
-    raise StandardError.new("#{resp.code} error while fetching: #{resp.body}") unless %w(201 200).include?(resp.code.to_s)
+    return [] if %w[404].include?(resp.code.to_s)
+    # TODO: handle non 200 response code. Throwing an exception for now
+    raise StandardError, "#{resp.code} error while fetching: #{resp.body}" unless %w[201
+                                                                                     200].include?(resp.code.to_s)
 
     parsed_response = JSON.parse(resp.body)
 
     if criteria[:count]
-      raise StandardError.new("Count is not supported for #{@klass}") if parsed_response.is_a?(Array)
+      raise StandardError, "Count is not supported for #{@klass}" if parsed_response.is_a?(Array)
 
-      results = parsed_response["totalCount"]
-      return results.to_i
+      results = parsed_response['totalCount']
+      results.to_i
     else
-      results = parsed_response.is_a?(Array) ? parsed_response : parsed_response["records"]
+      results = parsed_response.is_a?(Array) ? parsed_response : parsed_response['records']
       return [] if results.blank?
+
       results = results[0..(criteria[:limit] - 1)] if criteria[:limit]
-      records = get_relation_objects results.map { |r|
+      records = get_relation_objects(results.map do |r|
         # Convert camelcase to snake-case
         r = r.transform_keys { |key| key.underscore }
         @klass.model_name.to_s.constantize.new(r, false)
-      }
+      end)
 
       if criteria[:with_count]
-        [records, parsed_response["totalCount"]]
+        [records, parsed_response['totalCount']]
       else
         records
       end
@@ -274,9 +307,11 @@ class Lockstep::Query
           next unless included_objects.include?(relation.to_s.downcase)
 
           if !item.attributes.has_key?(relation.to_s)
-            item.attributes[relation.to_s] = Lockstep::RelationArray.new(@klass, [], relation, relation_config[:class_name])
+            item.attributes[relation.to_s] =
+              Lockstep::RelationArray.new(@klass, [], relation, relation_config[:class_name])
           elsif !item.attributes[relation].is_a?(Lockstep::RelationArray)
-            item.attributes[relation.to_s] = Lockstep::RelationArray.new(@klass, item.attributes[relation], relation, relation_config[:class_name])
+            item.attributes[relation.to_s] =
+              Lockstep::RelationArray.new(@klass, item.attributes[relation], relation, relation_config[:class_name])
           end
         end
       end
@@ -347,15 +382,17 @@ class Lockstep::Query
   # @return [Lockstep::ApiRecord] an object that subclasses Lockstep::ApiRecord.
   def find(id)
     raise Lockstep::Exceptions::RecordNotFound, "Couldn't find #{name} without an ID" if id.blank?
+
     record = where(@klass.id_ref => id).first
     raise Lockstep::Exceptions::RecordNotFound, "Couldn't find #{name} with id: #{id}" if record.blank?
+
     record
   end
 
   def method_missing(meth, *args, &block)
     method_name = method_name.to_s
-    if method_name.start_with?("find_by_")
-      attrib = method_name.gsub(/^find_by_/, "")
+    if method_name.start_with?('find_by_')
+      attrib = method_name.gsub(/^find_by_/, '')
       finder_name = "find_all_by_#{attrib}"
 
       define_singleton_method(finder_name) do |target_value|
@@ -363,8 +400,8 @@ class Lockstep::Query
       end
 
       send(finder_name, args[0])
-    elsif method_name.start_with?("find_all_by_")
-      attrib = method_name.gsub(/^find_all_by_/, "")
+    elsif method_name.start_with?('find_all_by_')
+      attrib = method_name.gsub(/^find_all_by_/, '')
       finder_name = "find_all_by_#{attrib}"
 
       define_singleton_method(finder_name) do |target_value|
@@ -375,7 +412,7 @@ class Lockstep::Query
     end
 
     if @klass.scopes[meth].present?
-      instance_exec *args, &@klass.scopes[meth]
+      instance_exec(*args, &@klass.scopes[meth])
     elsif Array.method_defined?(meth)
       all.send(meth, *args, &block)
     else
@@ -398,7 +435,8 @@ class Lockstep::Query
   private
 
   def turn_relation_hash_into_object(relation, hash)
-    return nil if hash == nil
+    return nil if hash.nil?
+
     relation_klass = relation[:class_name].to_s.constantize
     relation_object = relation_klass.new
     hash.each do |key, value|
@@ -414,18 +452,20 @@ class Lockstep::Query
 
       if value.is_a?(Array) and class_name_in_a_hash
         value.each do |object_in_array|
-          fresh_object = turn_relation_hash_into_object(relation_klass.has_many_relations[key][:class_name], object_in_array)
+          fresh_object = turn_relation_hash_into_object(relation_klass.has_many_relations[key][:class_name],
+                                                        object_in_array)
           value[value.index(object_in_array)] = fresh_object
         end
         # Convert key from camelcase to snake-case
         relation_object.attributes[key.underscore] = value
       elsif value.is_a?(Hash) and relation_klass.belongs_to_relations[key].present?
         # Convert key from camelcase to snake-case
-        relation_object.attributes[key.underscore] = turn_relation_hash_into_object(relation_klass.belongs_to_relations[key][:class_name], value)
-      else
-        # Convert key from camelcase to snake-case
-        relation_object.attributes[key.underscore] = value if key.to_s != "__type" and key.to_s != "className"
+        relation_object.attributes[key.underscore] =
+          turn_relation_hash_into_object(relation_klass.belongs_to_relations[key][:class_name], value)
+      elsif key.to_s != '__type' and key.to_s != 'className'
+        relation_object.attributes[key.underscore] = value
       end
+      # Convert key from camelcase to snake-case
     end
 
     relation_object

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = '0.3.63'
+  VERSION = '0.3.64'
 end


### PR DESCRIPTION
## Why?
Highlighted in this [Notion Document](https://www.notion.so/lockstep/Data-Sync-Fix-Planning-610bd0a2d609455992e440087f97f46b?pvs=4).

To summarise:
We need to save the fetched records from platform in a batched fashion rather than fetch all -> save all pattern.

## What's Changed?
- [x] Added #in_batches and self#in_batches methods
(Waiting for initial review)
- [ ] Default sort (modified: :asc)
- [ ] Test Cases
- [ ] Implementation in Inbox.

## Implementation Example
#### self.in_batches
```ruby
Lockstep::InvoiceSummary.in_batches(batch_size: 500) do |batch|
  Platform::InvoiceSummary.upsert_all(batch)
end
```

#### where_chain#in_batches
```ruby
Lockstep::InvoiceSummary.where(modified_gteq: 2.weeks.ago).limit(50).in_batches(batch_size: 10) do |batch|
  Platform::InvoiceSummary.upsert_all(batch)
end
```