### PR TITLE
Add bulk destroy for platform models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.63)
+    lockstep_rails (0.3.64)
       rails
 
 GEM

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ if you wish, you can always write raw [Searchlight](https://developer.lockstep.i
 Lockstep::Connection.where("isActive is true OR default_currency_code in ('USD', 'INR')").execute
 ```
 
+### Destroy and Destroy all
+You can destroy a single object by calling destroy method on one object
+Lockstep::Connection.find(company_id: "17544da8-7be8-4ee2-8c62-cbd81428c68b").destroy
+
+You can also destroy multiple objects at once by calling it on the model class and passing an array of relevant ids
+
+Lockstep::Connection.destroy_all(id: ["17544da8-7be8-4ee2-8c62-cbd81428c68b"])
+
 ### Count
 You can fetch the count of available records by calling `count`
 

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -819,6 +819,7 @@ module Lockstep
       id.each_slice(100) do |sliced_ids|
         resp = resource.delete('', body: { 'idsToDelete' => sliced_ids })
         return false unless resp.code.to_s == '200'
+        # TODO: Since this could fail for certain IDs return deleted_ids in batch
       end
       
       @attributes = {}

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -572,13 +572,6 @@ module Lockstep
       obj
     end
 
-    # Replaced with a batch destroy_all method.
-    # def self.destroy_all(all)
-    #   all.each do |object|
-    #     object.destroy
-    #   end
-    # end
-
     def self.class_attributes
       @class_attributes ||= {}
     end
@@ -820,6 +813,10 @@ module Lockstep
         return true
       end
       false
+    end
+
+    def self.destroy_all(ids_to_delete = [])
+      resp = resource.delete('', body: { 'idsToDelete' => ids_to_delete })
     end
 
     def reload

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -817,6 +817,12 @@ module Lockstep
 
     def self.destroy_all(ids_to_delete = [])
       resp = resource.delete('', body: { 'idsToDelete' => ids_to_delete })
+      if resp.code.to_s == '200'
+        @attributes = {}
+        @unsaved_attributes = {}
+        return true
+      end
+      false
     end
 
     def reload

--- a/app/concepts/lockstep/api_record.rb
+++ b/app/concepts/lockstep/api_record.rb
@@ -815,14 +815,15 @@ module Lockstep
       false
     end
 
-    def self.destroy_all(ids_to_delete = [])
-      resp = resource.delete('', body: { 'idsToDelete' => ids_to_delete })
-      if resp.code.to_s == '200'
-        @attributes = {}
-        @unsaved_attributes = {}
-        return true
+    def self.destroy_all(id: [])
+      id.each_slice(100) do |sliced_ids|
+        resp = resource.delete('', body: { 'idsToDelete' => sliced_ids })
+        return false unless resp.code.to_s == '200'
       end
-      false
+      
+      @attributes = {}
+      @unsaved_attributes = {}
+      return true
     end
 
     def reload

--- a/app/concepts/lockstep/client.rb
+++ b/app/concepts/lockstep/client.rb
@@ -159,8 +159,8 @@ module Lockstep
       request(:put, path, body, params)
     end
 
-    def delete(path)
-      request(:delete, path, {}, {})
+    def delete(path, body: {})
+      request(:delete, path, body, {})
     end
 
     def post_magic_link(path, body: {}, params: {})

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,3 +1,3 @@
 module LockstepRails
-  VERSION = '0.3.63'
+  VERSION = '0.3.64'
 end


### PR DESCRIPTION
Create a new destroy_all method that accepts an array of ids to delete which are used to mark all the records inactive in bulk.

It calls the Platform's bulk delete api in the background. 

Dev testing evidence - 

Two active connections - 
<img width="1512" alt="Screenshot 2023-06-07 at 07 38 21" src="https://github.com/Lockstep-Network/lockstep-sdk-ruby-rails/assets/31181534/556b6c8a-23a1-4339-9236-696f94fa2875">

Call destroy_all on those two, returns 200
<img width="979" alt="Screenshot 2023-06-07 at 07 40 01" src="https://github.com/Lockstep-Network/lockstep-sdk-ruby-rails/assets/31181534/0ceb3a44-f663-4729-a0d5-01f74ca41553">

Marks both as inactive
![Uploading Screenshot 2023-06-07 at 07.40.46.png…]()

Calling destroy on a single record also marks it as false
<img width="1020" alt="Screenshot 2023-06-07 at 07 42 58" src="https://github.com/Lockstep-Network/lockstep-sdk-ruby-rails/assets/31181534/6318a9be-d1b6-4a9a-8da7-f7fe818d145d">

