### PR TITLE
Fixing Count Method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.75)
+    lockstep_rails (0.3.76)
       rails
 
 GEM
@@ -121,7 +121,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.0)
     minitest (5.16.2)
-    net-imap (0.4.6)
+    net-imap (0.4.8)
       date
       net-protocol
     net-pop (0.1.2)
@@ -130,7 +130,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.6.1)
+    nio4r (2.7.0)
     nokogiri (1.13.7)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)

--- a/app/concepts/lockstep/query.rb
+++ b/app/concepts/lockstep/query.rb
@@ -337,8 +337,7 @@ class Lockstep::Query
   end
 
   def count
-    criteria[:count] = true
-    execute
+    with_clone { criteria[:count] = true }.execute
   end
 
   # Find a Lockstep::ApiRecord object by ID

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LockstepRails
-  VERSION = '0.3.75'
+  VERSION = '0.3.76'
 end


### PR DESCRIPTION
## Issue Description
In previous versions, when a built query was chained with a count method, any previous references to the same query would be modified as well. This is a fix for that issue.

For example:
```ruby
> query = Lockstep::Invoice.where(invoice_type_code: 'AR Invoice') # => #<Lockstep::Query:0x00000001381073c0 @criteria={:conditions=>[{:invoice_type_code=>"AR Invoice"}]}, @klass=Lockstep::Invoice>
> count_query = query.count # => 4
> p query # => #<Lockstep::Query:0x00000001381073c0 @criteria={:conditions=>[{:invoice_type_code=>"AR Invoice"}], :count=>true}, @klass=Lockstep::Invoice>
```

The original query object got updated which is a side-effect and shouldn't have updated.

## What's Changed
The addition of count is done using the `with_clone` helper causing the original query to not be referenced while being executed.

The above example repeated after this change:
```ruby
> query = Lockstep::Invoice.where(invoice_type_code: 'AR Invoice') # => #<Lockstep::Query:0x00000001381073c0 @criteria={:conditions=>[{:invoice_type_code=>"AR Invoice"}]}, @klass=Lockstep::Invoice>
> count_query = query.count # => 4
> p query # => #<Lockstep::Query:0x00000001381073c0 @criteria={:conditions=>[{:invoice_type_code=>"AR Invoice"}]}, @klass=Lockstep::Invoice>
```

## Local Sanity

Before:
<img width="725" alt="image" src="https://github.com/Lockstep-Network/lockstep-sdk-ruby-rails/assets/74608924/31851876-0377-48fc-a03a-7eca1709875f">

After:
<img width="653" alt="image" src="https://github.com/Lockstep-Network/lockstep-sdk-ruby-rails/assets/74608924/dbe5a00e-76c6-4784-9972-604578cbf870">
