### PR TITLE
Add magic link summary model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.77)
+    lockstep_rails (0.3.78)
       rails
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.76)
+    lockstep_rails (0.3.77)
       rails
 
 GEM

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The gem is available as open source under the terms of the [MIT License](https:/
 - Lockstep::InvoiceAtRiskSummary
 - Lockstep::InvoiceSummary
 - Lockstep::MagicLink
+- Lockstep::MagicLinkSummary
 - Lockstep::Note
 - Lockstep::Payments
 - Lockstep::PaymentApplied

--- a/app/concepts/lockstep/exceptions.rb
+++ b/app/concepts/lockstep/exceptions.rb
@@ -2,4 +2,5 @@ module Lockstep::Exceptions
   class UnauthorizedError < StandardError; end
   class BadRequestError < StandardError; end
   class RecordNotFound < StandardError; end
+  class ApiResponseError < StandardError; end
 end

--- a/app/models/lockstep/magic_link_summary.rb
+++ b/app/models/lockstep/magic_link_summary.rb
@@ -7,7 +7,7 @@ class Lockstep::MagicLinkSummary < Lockstep::ApiRecord
   def self.with_date(from_date: nil, to_date: nil)
   	resp = resource.get('', params: { from: from_date, to: to_date })
     raise Lockstep::Exceptions::BadRequestError, 'Endpoint not found' if resp.code == '404'
-    raise StandardError.new("#{resp.code} error while fetching: #{resp.body}") unless %w(201 200 204).include?(resp.code.to_s)
+    raise Lockstep::Exceptions::ApiResponseError.new("#{resp.code} error while fetching: #{resp.body}") unless %w(201 200).include?(resp.code.to_s)
 
     summary = JSON.parse(resp.body)
 

--- a/app/models/lockstep/magic_link_summary.rb
+++ b/app/models/lockstep/magic_link_summary.rb
@@ -1,0 +1,10 @@
+class Lockstep::MagicLinkSummary < Lockstep::ApiRecord
+  self.model_name_uri = "v1/useraccounts/magic-links/summary"
+  self.id_ref = "group_key"
+  self.query_path = ""
+  load_schema(Schema::MagicLinkSummary)
+
+  def self.with_date(from_date: nil, to_date: nil)
+  	additional_query_params({"from": from_date, "to": to_date})
+  end
+end

--- a/app/models/lockstep/magic_link_summary.rb
+++ b/app/models/lockstep/magic_link_summary.rb
@@ -5,6 +5,12 @@ class Lockstep::MagicLinkSummary < Lockstep::ApiRecord
   load_schema(Schema::MagicLinkSummary)
 
   def self.with_date(from_date: nil, to_date: nil)
-  	additional_query_params({"from": from_date, "to": to_date})
+  	resp = resource.get('', params: { from: from_date, to: to_date })
+    raise Lockstep::Exceptions::BadRequestError, 'Endpoint not found' if resp.code == '404'
+    raise StandardError.new("#{resp.code} error while fetching: #{resp.body}") unless %w(201 200 204).include?(resp.code.to_s)
+
+    summary = JSON.parse(resp.body)
+
+    summary.deep_transform_keys!(&:underscore).deep_symbolize_keys!
   end
 end

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LockstepRails
-  VERSION = '0.3.77'
+  VERSION = '0.3.78'
 end

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LockstepRails
-  VERSION = '0.3.76'
+  VERSION = '0.3.77'
 end


### PR DESCRIPTION
Add a new model MagicLinkSummary to the gem

This model will have `with_date` method that helps get data from it. 

Local testing - 
<img width="872" alt="Screenshot 2023-12-26 at 23 33 45" src="https://github.com/Lockstep-Network/lockstep-sdk-ruby-rails/assets/31181534/9e5bfd81-2c9a-414f-b279-e538b2e3130d">
