### PR TITLE
add pdf endpoint to invoice and payments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.82)
+    lockstep_rails (0.3.83)
       rails
 
 GEM

--- a/app/models/lockstep/invoice.rb
+++ b/app/models/lockstep/invoice.rb
@@ -11,4 +11,9 @@ class Lockstep::Invoice < Lockstep::ApiRecord
   scope :einvoices, -> { where(is_e_invoice: true).include_object(:customer, :lines, :attachments) }
   scope :received_einvoices, -> { einvoices.where(invoice_type_code: 'AP Invoice') }
   scope :sent_einvoices, -> { einvoices.where(invoice_type_code: 'AR Invoice') }
+
+  def download_pdf
+    response = resource.get "#{id}/pdf"
+    response.body
+  end
 end

--- a/app/models/lockstep/payment.rb
+++ b/app/models/lockstep/payment.rb
@@ -19,4 +19,9 @@ class Lockstep::Payment < Lockstep::ApiRecord
       result = post_result(resp)
     end
   end
+
+  def download_pdf
+    response = resource.get "#{id}/pdf"
+    response.body
+  end
 end

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LockstepRails
-  VERSION = '0.3.82'
+  VERSION = '0.3.83'
 end


### PR DESCRIPTION
Add two new endpoints to retrieve PDFs for Invoices and Payments. These endpoints are available on swagger and return only the PDF body in the response