### PR TITLE
added new method into workflow_status to include children of workflow statuses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lockstep_rails (0.3.84)
+    lockstep_rails (0.3.85)
       rails
 
 GEM

--- a/app/models/lockstep/workflow_status.rb
+++ b/app/models/lockstep/workflow_status.rb
@@ -5,4 +5,22 @@ class Lockstep::WorkflowStatus < Lockstep::ApiRecord
   self.id_ref = 'id'
 
   load_schema(Schema::WorkflowStatus)
+
+  def self.retrieve_by_id_with_children(id)
+    resp = resource.get("#{id}", params: { include: :children })
+    parsed_response = JSON.parse(resp.body)
+    
+    case resp.code.to_s
+    when '401'
+      raise Lockstep::Exceptions::UnauthorizedError, parsed_response['title']
+    when '400'
+      raise Lockstep::Exceptions::BadRequestError, parsed_response['title']
+    when '404'
+      raise Lockstep::Exceptions::RecordNotFound, parsed_response['title']
+    when '200'
+      parsed_response.deep_transform_keys(&:underscore)
+    else
+      raise Lockstep::Exceptions::BadRequestError, parsed_response
+    end
+  end
 end

--- a/lib/lockstep_rails/version.rb
+++ b/lib/lockstep_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LockstepRails
-  VERSION = '0.3.84'
+  VERSION = '0.3.85'
 end


### PR DESCRIPTION
swagger URL: https://api.network.sage.com/swagger/index.html#/WorkflowStatuses/v1_WorkflowStatuses_RetrieveWorkflowStatus

for the model `Lockstep::WorkflowStatus`, added a new method which will fetch a workflow status by its ID and it will also include its children where children are the next possbile actions.

E.g. "Submitted" (id: 00000000-0000-0000-0000-100000000000) is a workflow status and its has two children:
1. "Made Available" (id: 00000000-0000-0000-0000-300000000000)
2. "Rejected" (id: 00000000-0000-0000-0000-130000000000)